### PR TITLE
Fetch the last n messages when joining

### DIFF
--- a/config_example.js
+++ b/config_example.js
@@ -7,6 +7,9 @@ global.configuration = {
       keyPath: '/path/to/key.pem',
       certPath: '/path/to/cert.pem'
     },
+    discord: {
+      messageLimit: 20
+    },
     handleCode: true, 
     githubToken: '<TOKEN>',
     ircServer: {

--- a/server.js
+++ b/server.js
@@ -1044,7 +1044,7 @@ function joinCommand(channel, discordID, socketID) {
                 // We check if the message we're about to send has more than 1 line.
                 // If it does, then we need to send them one by one. Otherwise the client
                 // will try to interpret them as commands.
-                const lines = msg.cleanContent.split("\r\n");
+                const lines = msg.cleanContent.split(/\r?\n/);
                 if (lines.length > 1) {
                     for (let i = 0; i < lines.length; i++)
                      sendToIRC(discordID, `:${configuration.ircServer.hostname} PRIVMSG #${channel} ${msg.author.username} :${lines[i]}\r\n`, socketID);

--- a/server.js
+++ b/server.js
@@ -1037,8 +1037,14 @@ function joinCommand(channel, discordID, socketID) {
             }
         }
 
+        // If the amount of messages to be fetched after joining is set to 0,
+        // then we just exit the function here. Nothing, besides fetching the
+        // messages, happens after here, so it's okay
+        const messageLimit = configuration.discord.messageLimit;
+        if (messageLimit === 0) return;
+        
         // Fetch the last n Messages
-        channelContent.fetchMessages({limit: configuration.discord.messageLimit}).then((messages) => {
+        channelContent.fetchMessages({limit: messageLimit}).then((messages) => {
             console.log(`Fetched messages for "${channel}"`);
             // For some reason the messages are not ordered. So we need to sort
             // them by creation date before we do anything.

--- a/server.js
+++ b/server.js
@@ -1038,7 +1038,7 @@ function joinCommand(channel, discordID, socketID) {
         }
 
         // Fetch the last 20 Messages
-        channelContent.fetchMessages({limit: 20}).then((messages) => {
+        channelContent.fetchMessages({limit: configuration.discord.messageLimit}).then((messages) => {
             console.log(`Fetched messages for "${channel}"`);
             messages.array().forEach((msg) => {
                 // We check if the message we're about to send has more than 1 line.

--- a/server.js
+++ b/server.js
@@ -1050,8 +1050,9 @@ function joinCommand(channel, discordID, socketID) {
                 // will try to interpret them as commands.
                 const lines = msg.cleanContent.split(/\r?\n/);
                 if (lines.length > 1) {
-                    for (let i = 0; i < lines.length; i++)
+                    for (let i = 0; i < lines.length; i++) {
                         sendToIRC(discordID, `:${configuration.ircServer.hostname} PRIVMSG #${channel} ${msg.author.username} :${lines[i]}\r\n`, socketID);
+                    }
                 } else {
                     sendToIRC(discordID, `:${configuration.ircServer.hostname} PRIVMSG #${channel} ${msg.author.username} :${msg.cleanContent}\r\n`, socketID);
                 }

--- a/server.js
+++ b/server.js
@@ -1051,7 +1051,7 @@ function joinCommand(channel, discordID, socketID) {
                 const lines = msg.cleanContent.split(/\r?\n/);
                 if (lines.length > 1) {
                     for (let i = 0; i < lines.length; i++)
-                     sendToIRC(discordID, `:${configuration.ircServer.hostname} PRIVMSG #${channel} ${msg.author.username} :${lines[i]}\r\n`, socketID);
+                        sendToIRC(discordID, `:${configuration.ircServer.hostname} PRIVMSG #${channel} ${msg.author.username} :${lines[i]}\r\n`, socketID);
                 } else {
                     sendToIRC(discordID, `:${configuration.ircServer.hostname} PRIVMSG #${channel} ${msg.author.username} :${msg.cleanContent}\r\n`, socketID);
                 }

--- a/server.js
+++ b/server.js
@@ -1037,7 +1037,22 @@ function joinCommand(channel, discordID, socketID) {
             }
         }
 
-
+        // Fetch the last 20 Messages
+        channelContent.fetchMessages({limit: 20}).then((messages) => {
+            console.log(`Fetched messages for "${channel}"`);
+            messages.array().forEach((msg) => {
+                // We check if the message we're about to send has more than 1 line.
+                // If it does, then we need to send them one by one. Otherwise the client
+                // will try to interpret them as commands.
+                const lines = msg.cleanContent.split("\r\n");
+                if (lines.length > 1) {
+                    for (let i = 0; i < lines.length; i++)
+                     sendToIRC(discordID, `:${configuration.ircServer.hostname} PRIVMSG #${channel} ${msg.author.username} :${lines[i]}\r\n`, socketID);
+                } else {
+                    sendToIRC(discordID, `:${configuration.ircServer.hostname} PRIVMSG #${channel} ${msg.author.username} :${msg.cleanContent}\r\n`, socketID);
+                }
+            });
+        });
 
     } else {
         sendToIRC(discordID, `:${configuration.ircServer.hostname} 473 ${nickname} #${channel} :Cannot join channel\r\n`, socketID);

--- a/server.js
+++ b/server.js
@@ -1037,10 +1037,14 @@ function joinCommand(channel, discordID, socketID) {
             }
         }
 
-        // Fetch the last 20 Messages
+        // Fetch the last n Messages
         channelContent.fetchMessages({limit: configuration.discord.messageLimit}).then((messages) => {
             console.log(`Fetched messages for "${channel}"`);
-            messages.array().forEach((msg) => {
+            // For some reason the messages are not ordered. So we need to sort
+            // them by creation date before we do anything.
+            messages.array().sort((msgA, msgB) => {
+                return msgA.createdAt - msgB.createdAt;
+            }).forEach((msg) => {
                 // We check if the message we're about to send has more than 1 line.
                 // If it does, then we need to send them one by one. Otherwise the client
                 // will try to interpret them as commands.


### PR DESCRIPTION
Whenever a client issues a join-command, we want the server to fetch the last n messages that
were sent in that channel and send them to the client.

The amount of messages is configurable and defaults to 20 messages, which I feel is reasonable.