### PR TITLE
Fix Unknown CTCP when the start of a message, but not the entire message, is in italics

### DIFF
--- a/server.js
+++ b/server.js
@@ -116,7 +116,7 @@ function parseDiscordLine(line, discordID) {
     // Discord markdown parsing the lazy way. Probably fails in a bunch of different ways but at least it is easy. 
     line = line.replace(/\*\*(.*?)\*\*/g, '\x02$1\x0F');
     line = line.replace(/\*(.*?)\*/g, '\x1D$1\x0F');
-    line = line.replace(/^_(.*?)\_/g, '\x01ACTION $1\x01');
+    line = line.replace(/^_(.*?)\_$/g, '\x01ACTION $1\x01');
     line = line.replace(/__(.*?)__/g, '\x1F$1\x0F');
 
     // With the above regex we might end up with to many end characters. This replaces the, 


### PR DESCRIPTION
Before, a message from discord such as `_Probably_ the former` would be incorrectly detected as a `/me`-type message, producing broken output when the replacement was done (https://i.imgur.com/RW7r1qL.png).  Now, `/me` detection requires the whole message to be in italics.

The conversion is still rather lazy and fails in some edge cases (e.g. multiline /me), but discord's implementation of /me is also rather lazy (it fails when there's an underscore in the message) so it doesn't really matter.  This at least produces sane output.