### PR TITLE
Add bi-directional topic setting, mode support, discord status matching

### DIFF
--- a/config_example.js
+++ b/config_example.js
@@ -1,6 +1,7 @@
 global.configuration = {
     DEBUG: false,
     showOfflineUsers: true, // When true all users will always be shown. Offline users will be shown as away on clients that support away-notify.
+    matchClientStatus: true, // When true the discord user's status will be idle on startup, online if a client is connected, dnd when client disconnects
     discordToken: '<TOKEN>',
     tlsEnabled: true,
     tlsOptions: {


### PR DESCRIPTION
This adds:
- TOPIC support: setting Discord channel topics. Updates are pushed two-way, setting it in an IRC client updates the actual server (guild), topic changes in a discord guild/server are also pushed to IRC clients.
- MODE support: basic implementation of the MODE command. It includes a static bot list, mainly because mIRC requires this to even open the channel editor/channel central to set the topic interactively.
- LUSERS bugfix, forgot to add member/channel cache

New feature:
- status matching: On discordIRCd start, the user's stats is set to Idle. When a client connect, status is set to Online. When the last client disconnects, the status is set to dnd aka nobody's connected. Offline is reserved for actual offline-ness.